### PR TITLE
ci(commit): change to use semver

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,16 +23,18 @@ jobs:
         with:
           go-version: stable
 
-      - name: Get latest commit-lint commit hash
+      - name: Get latest commit-lint semver tag
         id: commitlint-version
-        run: echo "hash=$(git ls-remote https://github.com/takara-ai/commit-lint HEAD | cut -f1)" >> $GITHUB_OUTPUT
+        run: |
+          latest_tag=$(go list -m -versions github.com/takara-ai/commit-lint | awk '{print $NF}')
+          echo "tag=$latest_tag" >> $GITHUB_OUTPUT
 
       - name: Restore commit-lint binary
         id: cache-commit-lint
         uses: actions/cache/restore@v4
         with:
           path: .cache/commit-lint
-          key: commit-lint-${{ runner.os }}-go-${{ steps.commitlint-version.outputs.hash }}
+          key: commit-lint-${{ runner.os }}-go-${{ steps.commitlint-version.outputs.tag }}
           restore-keys: |
             commit-lint-${{ runner.os }}-
 
@@ -40,7 +42,7 @@ jobs:
         if: steps.cache-commit-lint.outputs.cache-hit != 'true'
         run: |
           mkdir -p .cache
-          GOBIN=$PWD/.cache GO111MODULE=on go install github.com/takara-ai/commit-lint@latest
+          GOBIN=$PWD/.cache GO111MODULE=on go install github.com/takara-ai/commit-lint@${{ steps.commitlint-version.outputs.tag }}
 
       - name: Run commit-lint
         run: .cache/commit-lint
@@ -53,7 +55,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .cache/commit-lint
-          key: commit-lint-${{ runner.os }}-go-${{ steps.commitlint-version.outputs.hash }}
+          key: commit-lint-${{ runner.os }}-go-${{ steps.commitlint-version.outputs.tag }}
 
   python:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,12 +23,15 @@ jobs:
         with:
           go-version: stable
 
+      # Get the latest semver tag for commit-lint using the Go module proxy.
+      # This ensures we only update the cache when a new release is published.
       - name: Get latest commit-lint semver tag
         id: commitlint-version
         run: |
           latest_tag=$(go list -m -versions github.com/takara-ai/commit-lint | awk '{print $NF}')
           echo "tag=$latest_tag" >> $GITHUB_OUTPUT
 
+      # Restore the commit-lint binary from cache if it was previously built for this semver tag.
       - name: Restore commit-lint binary
         id: cache-commit-lint
         uses: actions/cache/restore@v4
@@ -38,18 +41,21 @@ jobs:
           restore-keys: |
             commit-lint-${{ runner.os }}-
 
+      # Install commit-lint at the specific semver tag if not found in cache.
       - name: Install commit-lint
         if: steps.cache-commit-lint.outputs.cache-hit != 'true'
         run: |
           mkdir -p .cache
           GOBIN=$PWD/.cache GO111MODULE=on go install github.com/takara-ai/commit-lint@${{ steps.commitlint-version.outputs.tag }}
 
+      # Run the commit-lint binary to check commit messages.
       - name: Run commit-lint
         run: .cache/commit-lint
         env:
           ALLOW_CAPITAL_SUBJECT: "true"
           MAX_SUBJECT: "102"
 
+      # Save the built commit-lint binary to cache for future runs.
       - name: Save commit-lint binary to cache
         if: always() && steps.cache-commit-lint.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4


### PR DESCRIPTION
## Describe your changes
What was changed and why this change was needed

- **What**: Updated commit-lint caching strategy in `.github/workflows/linting.yml` to use semver tags instead of commit hashes, and added explanatory comments for transparency
- **Why**: To improve caching efficiency by only updating the cache when new releases are published (semver tags) rather than on every commit, and to make the workflow more maintainable with clear documentation

## Issue ticket number and link
N/A - Direct improvement to workflow efficiency

## Checklist before requesting a review
- [x] PR title follows conventional commit format (e.g., `feat: add user authentication`, `fix: resolve API timeout`)
- [x] I have performed a self-review of my code
- [x] Tests pass
- [x] Documentation updated if needed